### PR TITLE
Add Swift Testing library as a standard module

### DIFF
--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -141,6 +141,7 @@ public actor ImportScanner {
         // Common Swift standard library and platform modules that don't require explicit dependencies
         let standardModules: Set<String> = [
             "Swift",
+            "Testing",
             "Foundation",
             "Dispatch",
             "CoreFoundation",

--- a/Tests/SwiftDependencyAuditTests/ImportScannerTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ImportScannerTests.swift
@@ -111,6 +111,7 @@ struct ImportScannerTests {
         let scanner = ImportScanner()
         let content = """
             import Swift
+            import Testing
             import Foundation
             import Dispatch
             import UIKit


### PR DESCRIPTION
[Swift Testing](https://github.com/swiftlang/swift-testing) doesn't need to be added as a dependency in the package, so I think it should be listed in the standard modules.

This is awesome by the way, thanks @tonyarnold! ☺️