### PR TITLE
Add product-level dependency detection and analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - File-specific error reporting with exact line numbers
 
 ### Fixed
+- **Exit Code Handling**
+  - Redundant direct dependencies now generate warnings instead of errors
+  - Tool exits with code 0 when only warnings are present (no missing or unused dependencies)
+  - Improved CI compatibility by treating redundant dependencies as non-blocking warnings
+
 - **Package.swift Parser Robustness**
   - Fixed parsing failures with complex Package.swift files using variable declarations
   - Enhanced bracket counting for nested array structures in variable assignments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced JSON output to include detailed product/package attribution for redundant dependencies
   - Improved actionability of redundant dependency warnings with complete provenance information
 
+### Fixed
+- **Product vs Target Dependency Detection**
+  - Fixed false positive redundant dependency warnings for product dependencies with matching target names
+  - Product dependencies like `.product(name: "Apollo", package: "apollo-ios")` are no longer incorrectly flagged as redundant
+  - Enhanced dependency parsing to properly distinguish between product dependencies and target dependencies
+  - Corrected redundancy detection to only flag actual target dependencies that are covered by product dependencies
+  - Resolves issue where tools reported confusing messages like "Apollo (available through Apollo from Apollo)"
+
 - **Package.swift Parser Robustness**
   - Fixed parsing failures with complex Package.swift files using variable declarations
   - Enhanced bracket counting for nested array structures in variable assignments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Product-Level Dependency Detection**
+  - Analyzes external package products from `.build/checkouts` directory after `swift resolve`
+  - Detects imports satisfied by product dependencies to prevent false "missing dependency" reports
+  - Identifies redundant direct target dependencies when covered by product dependencies
+  - Enhanced verbose reporting shows product-to-target mappings and satisfied imports
+  - Seamless integration with existing whitelist functionality
+  - Comprehensive test coverage with 6 new tests using generic examples
+
 - **Enhanced Package.swift Parsing**
   - Support for variable-based Package.swift definitions (`let name = "..."`, `let targets = [...]`)
   - Variable resolution for package name, targets, dependencies, and products arrays
   - Support for complex Package.swift patterns with `targets.forEach` post-processing
   - Enhanced custom path support for targets with explicit `path:` parameters
   - Improved parsing of mixed target types (`.target`, `.testTarget`, `.executableTarget`, etc.)
+  - Product parsing with RegexBuilder patterns for `.library()`, `.executable()`, and `.plugin()` declarations
+  - External dependency extraction supporting both URL and path-based packages
   - All new parsing patterns implemented using RegexBuilder DSL for better maintainability
 
 - **IDE and CI/CD Integration**
@@ -38,21 +48,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced dependency parsing to capture exact line numbers where dependencies are declared
 
 ### Technical Details
-- Enhanced `PackageParser` with RegexBuilder-based variable resolution patterns
-- Added `resolveStringVariable()`, `resolveTargetsVariable()`, `resolveDependenciesVariable()` methods
-- Added `applyForEachModifications()` for handling target post-processing
-- Enhanced target parsing with custom path extraction using `pathParameter` pattern
-- Improved `extractVariableArrayContent()` with robust bracket counting
-- Enhanced `ImportInfo` model with line number tracking
-- Added `DependencyInfo` model to track dependency line numbers in Package.swift
-- Added `XcodeOutput` module for Xcode-compatible format (`file:line: error: message`)
-- Added `GitHubActionsOutput` module for GitHub Actions format (`::error file=path,line=N::message`)
-- Updated `ImportScanner` to capture line numbers during regex matching
-- Enhanced `PackageParser` with `parseDependencyListWithLineNumbers()` and `findDependencyLineNumber()` methods
-- Extended `DependencyAnalyzer` with `generateXcodeReport()` and `generateGitHubActionsReport()` methods
-- Fixed loop logic in `generateXcodeReport()` and `generateGitHubActionsReport()` to report all import occurrences
-- Updated `Target` model to include `dependencyInfo` array with line number tracking
-- All existing functionality preserved with backward compatibility - all 38 tests pass
+- **Product-Level Dependency Analysis**
+  - Added `Product`, `ExternalPackage`, `ExternalPackageDependency`, and `ProductSatisfiedDependency` models
+  - New `ExternalPackageResolver` actor for discovering and parsing external packages from `.build/checkouts`
+  - Enhanced `PackageParser` with product parsing using RegexBuilder patterns (`parseProductDeclaration`, `parseProductTargets`)
+  - Enhanced `DependencyAnalyzer` with two-level analysis supporting both product and target dependencies
+  - Added product-to-target mapping for external package analysis
+  - Enhanced `AnalysisResult` with `productSatisfiedDependencies` and `redundantDirectDependencies` fields
+  - Updated reporting logic to show product dependency information in verbose mode
+  - Package caching for performance optimization during external package parsing
+
+- **Enhanced Package.swift Parsing**
+  - Enhanced `PackageParser` with RegexBuilder-based variable resolution patterns
+  - Added `resolveStringVariable()`, `resolveTargetsVariable()`, `resolveDependenciesVariable()`, `resolveProductsVariable()` methods
+  - Added `extractProducts()` and `extractExternalDependencies()` methods with RegexBuilder patterns
+  - Added `applyForEachModifications()` for handling target post-processing
+  - Enhanced target parsing with custom path extraction using `pathParameter` pattern
+  - Improved `extractVariableArrayContent()` with robust bracket counting
+  - Added `extractPackageNameFromURL()` and `extractPackageNameFromPath()` utilities
+
+- **IDE and CI/CD Integration**
+  - Enhanced `ImportInfo` model with line number tracking
+  - Added `DependencyInfo` model to track dependency line numbers in Package.swift
+  - Added `XcodeOutput` module for Xcode-compatible format (`file:line: error: message`)
+  - Added `GitHubActionsOutput` module for GitHub Actions format (`::error file=path,line=N::message`)
+  - Updated `ImportScanner` to capture line numbers during regex matching
+  - Enhanced `PackageParser` with `parseDependencyListWithLineNumbers()` and `findDependencyLineNumber()` methods
+  - Extended `DependencyAnalyzer` with `generateXcodeReport()` and `generateGitHubActionsReport()` methods
+  - Fixed loop logic in `generateXcodeReport()` and `generateGitHubActionsReport()` to report all import occurrences
+  - Updated `Target` model to include `dependencyInfo` array with line number tracking
+
+- All existing functionality preserved with backward compatibility - all 44 tests pass (38 existing + 6 new)
 
 ## [1.0.0] - 2025-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Tool exits with code 0 when only warnings are present (no missing or unused dependencies)
   - Improved CI compatibility by treating redundant dependencies as non-blocking warnings
 
+### Enhanced
+- **Redundant Dependency Reporting**
+  - Enhanced redundant dependency warnings to show which specific product dependency provides each redundant direct dependency
+  - Updated output format: `• TargetName (available through ProductName from PackageName)`
+  - Enhanced JSON output to include detailed product/package attribution for redundant dependencies
+  - Improved actionability of redundant dependency warnings with complete provenance information
+
 - **Package.swift Parser Robustness**
   - Fixed parsing failures with complex Package.swift files using variable declarations
   - Enhanced bracket counting for nested array structures in variable assignments

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,3 +149,7 @@ See PROJECT_PLAN.md for detailed implementation phases and technical specificati
 ## Swift Development Best Practices
 
 - Use the RegexBuilder by default when designing regular expressions.
+
+## Testing Guidelines
+
+- Please do not include identifying information in any tests you create. No product or company names.

--- a/Sources/SwiftDependencyAuditLib/ExternalPackageResolver.swift
+++ b/Sources/SwiftDependencyAuditLib/ExternalPackageResolver.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public actor ExternalPackageResolver {
+    private static let maxSearchDepth = 5
     private let packageParser: PackageParser
     private var packageCache: [String: ExternalPackage] = [:]
     
@@ -42,7 +43,7 @@ public actor ExternalPackageResolver {
         
         // Try parent directories (in case we're in a subdirectory)
         var currentURL = packageURL.deletingLastPathComponent()
-        for _ in 0..<5 { // Limit search depth
+        for _ in 0..<Self.maxSearchDepth { // Limit search depth
             let buildURL = currentURL.appendingPathComponent(".build")
             let checkoutsURL = buildURL.appendingPathComponent("checkouts")
             

--- a/Sources/SwiftDependencyAuditLib/ExternalPackageResolver.swift
+++ b/Sources/SwiftDependencyAuditLib/ExternalPackageResolver.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+public actor ExternalPackageResolver {
+    private let packageParser: PackageParser
+    private var packageCache: [String: ExternalPackage] = [:]
+    
+    public init() {
+        self.packageParser = PackageParser()
+    }
+    
+    public func resolveExternalPackages(for packageInfo: PackageInfo) async throws -> [ExternalPackage] {
+        var externalPackages: [ExternalPackage] = []
+        
+        // Find .build/checkouts directory
+        let checkoutsPath = findCheckoutsDirectory(from: packageInfo.path)
+        
+        guard let checkoutsDir = checkoutsPath,
+              FileManager.default.fileExists(atPath: checkoutsDir) else {
+            // No checkouts directory found - packages may not be resolved yet
+            return externalPackages
+        }
+        
+        // Process each external dependency
+        for dependency in packageInfo.externalDependencies {
+            if let externalPackage = try await resolveExternalPackage(dependency: dependency, checkoutsPath: checkoutsDir) {
+                externalPackages.append(externalPackage)
+            }
+        }
+        
+        return externalPackages
+    }
+    
+    private func findCheckoutsDirectory(from packagePath: String) -> String? {
+        // Look for .build/checkouts relative to the package directory
+        let packageURL = URL(fileURLWithPath: packagePath)
+        let buildURL = packageURL.appendingPathComponent(".build")
+        let checkoutsURL = buildURL.appendingPathComponent("checkouts")
+        
+        if FileManager.default.fileExists(atPath: checkoutsURL.path) {
+            return checkoutsURL.path
+        }
+        
+        // Try parent directories (in case we're in a subdirectory)
+        var currentURL = packageURL.deletingLastPathComponent()
+        for _ in 0..<5 { // Limit search depth
+            let buildURL = currentURL.appendingPathComponent(".build")
+            let checkoutsURL = buildURL.appendingPathComponent("checkouts")
+            
+            if FileManager.default.fileExists(atPath: checkoutsURL.path) {
+                return checkoutsURL.path
+            }
+            
+            currentURL = currentURL.deletingLastPathComponent()
+        }
+        
+        return nil
+    }
+    
+    private func resolveExternalPackage(dependency: ExternalPackageDependency, checkoutsPath: String) async throws -> ExternalPackage? {
+        // Check cache first
+        if let cachedPackage = packageCache[dependency.packageName] {
+            return cachedPackage
+        }
+        
+        // Find the package directory in checkouts
+        let packageCheckoutPath = findPackageInCheckouts(packageName: dependency.packageName, checkoutsPath: checkoutsPath)
+        
+        guard let checkoutPath = packageCheckoutPath else {
+            // Package not found in checkouts
+            return nil
+        }
+        
+        // Parse the external package
+        let packageSwiftPath = URL(fileURLWithPath: checkoutPath).appendingPathComponent("Package.swift").path
+        
+        guard FileManager.default.fileExists(atPath: packageSwiftPath) else {
+            return nil
+        }
+        
+        do {
+            let externalPackageInfo = try await packageParser.parsePackage(at: packageSwiftPath)
+            let externalPackage = ExternalPackage(
+                name: externalPackageInfo.name,
+                products: externalPackageInfo.products,
+                path: checkoutPath
+            )
+            
+            // Cache the result
+            packageCache[dependency.packageName] = externalPackage
+            
+            return externalPackage
+        } catch {
+            // Failed to parse external package
+            return nil
+        }
+    }
+    
+    private func findPackageInCheckouts(packageName: String, checkoutsPath: String) -> String? {
+        let checkoutsURL = URL(fileURLWithPath: checkoutsPath)
+        
+        do {
+            let contents = try FileManager.default.contentsOfDirectory(atPath: checkoutsPath)
+            
+            var caseInsensitiveMatch: String?
+            var partialMatch: String?
+            
+            // Single pass with prioritized matching
+            for item in contents {
+                // Exact match (highest priority) - return immediately
+                if item == packageName {
+                    return checkoutsURL.appendingPathComponent(item).path
+                }
+                
+                // Store first case-insensitive match (medium priority)
+                if caseInsensitiveMatch == nil && item.lowercased() == packageName.lowercased() {
+                    caseInsensitiveMatch = item
+                }
+                
+                // Store first partial match (lowest priority)
+                if partialMatch == nil && (item.contains(packageName) || packageName.contains(item)) {
+                    partialMatch = item
+                }
+            }
+            
+            // Return best available match
+            if let match = caseInsensitiveMatch {
+                return checkoutsURL.appendingPathComponent(match).path
+            }
+            if let match = partialMatch {
+                return checkoutsURL.appendingPathComponent(match).path
+            }
+            
+        } catch {
+            // Failed to read checkouts directory
+            return nil
+        }
+        
+        return nil
+    }
+    
+    public func buildProductToTargetMapping(from externalPackages: [ExternalPackage]) -> [String: [String]] {
+        var mapping: [String: [String]] = [:]
+        
+        for package in externalPackages {
+            for product in package.products {
+                mapping[product.name] = product.targets
+            }
+        }
+        
+        return mapping
+    }
+}

--- a/Sources/SwiftDependencyAuditLib/Models.swift
+++ b/Sources/SwiftDependencyAuditLib/Models.swift
@@ -149,7 +149,11 @@ public struct AnalysisResult: Sendable {
     public let sourceFiles: [SourceFile]
     
     public var hasIssues: Bool {
-        !missingDependencies.isEmpty || !unusedDependencies.isEmpty || !redundantDirectDependencies.isEmpty
+        !missingDependencies.isEmpty || !unusedDependencies.isEmpty
+    }
+    
+    public var hasWarnings: Bool {
+        !redundantDirectDependencies.isEmpty
     }
     
     public init(target: Target, missingDependencies: Set<String>, unusedDependencies: Set<String>, correctDependencies: Set<String>, productSatisfiedDependencies: [ProductSatisfiedDependency] = [], redundantDirectDependencies: Set<String> = [], sourceFiles: [SourceFile]) {

--- a/Sources/SwiftDependencyAuditLib/Models.swift
+++ b/Sources/SwiftDependencyAuditLib/Models.swift
@@ -2,11 +2,18 @@ import Foundation
 
 public struct DependencyInfo: Sendable {
     public let name: String
+    public let type: DependencyType
     public let lineNumber: Int?
     
-    public init(name: String, lineNumber: Int? = nil) {
+    public init(name: String, type: DependencyType = .target, lineNumber: Int? = nil) {
         self.name = name
+        self.type = type
         self.lineNumber = lineNumber
+    }
+    
+    public enum DependencyType: Sendable {
+        case product(packageName: String)
+        case target
     }
 }
 
@@ -21,7 +28,7 @@ public struct Target: Sendable {
         self.name = name
         self.type = type
         self.dependencies = dependencies
-        self.dependencyInfo = dependencies.map { DependencyInfo(name: $0) }
+        self.dependencyInfo = dependencies.map { DependencyInfo(name: $0, type: .target) }
         self.path = path
     }
     

--- a/Sources/SwiftDependencyAuditLib/Models.swift
+++ b/Sources/SwiftDependencyAuditLib/Models.swift
@@ -43,16 +43,64 @@ public struct Target: Sendable {
     }
 }
 
+public struct Product: Sendable {
+    public let name: String
+    public let type: ProductType
+    public let targets: [String]
+    public let packageName: String
+    
+    public init(name: String, type: ProductType, targets: [String], packageName: String) {
+        self.name = name
+        self.type = type
+        self.targets = targets
+        self.packageName = packageName
+    }
+    
+    public enum ProductType: Sendable {
+        case library
+        case executable
+        case plugin
+    }
+}
+
+public struct ExternalPackageDependency: Sendable {
+    public let packageName: String
+    public let url: String?
+    public let path: String?
+    
+    public init(packageName: String, url: String? = nil, path: String? = nil) {
+        self.packageName = packageName
+        self.url = url
+        self.path = path
+    }
+}
+
+public struct ExternalPackage: Sendable {
+    public let name: String
+    public let products: [Product]
+    public let path: String
+    
+    public init(name: String, products: [Product], path: String) {
+        self.name = name
+        self.products = products
+        self.path = path
+    }
+}
+
 public struct PackageInfo: Sendable {
     public let name: String
     public let targets: [Target]
     public let dependencies: [String]
+    public let products: [Product]
+    public let externalDependencies: [ExternalPackageDependency]
     public let path: String
     
-    public init(name: String, targets: [Target], dependencies: [String], path: String) {
+    public init(name: String, targets: [Target], dependencies: [String], products: [Product] = [], externalDependencies: [ExternalPackageDependency] = [], path: String) {
         self.name = name
         self.targets = targets
         self.dependencies = dependencies
+        self.products = products
+        self.externalDependencies = externalDependencies
         self.path = path
     }
 }
@@ -79,22 +127,38 @@ public struct SourceFile: Sendable {
     }
 }
 
+public struct ProductSatisfiedDependency: Sendable {
+    public let importName: String
+    public let productName: String
+    public let packageName: String
+    
+    public init(importName: String, productName: String, packageName: String) {
+        self.importName = importName
+        self.productName = productName
+        self.packageName = packageName
+    }
+}
+
 public struct AnalysisResult: Sendable {
     public let target: Target
     public let missingDependencies: Set<String>
     public let unusedDependencies: Set<String>
     public let correctDependencies: Set<String>
+    public let productSatisfiedDependencies: [ProductSatisfiedDependency]
+    public let redundantDirectDependencies: Set<String>
     public let sourceFiles: [SourceFile]
     
     public var hasIssues: Bool {
-        !missingDependencies.isEmpty || !unusedDependencies.isEmpty
+        !missingDependencies.isEmpty || !unusedDependencies.isEmpty || !redundantDirectDependencies.isEmpty
     }
     
-    public init(target: Target, missingDependencies: Set<String>, unusedDependencies: Set<String>, correctDependencies: Set<String>, sourceFiles: [SourceFile]) {
+    public init(target: Target, missingDependencies: Set<String>, unusedDependencies: Set<String>, correctDependencies: Set<String>, productSatisfiedDependencies: [ProductSatisfiedDependency] = [], redundantDirectDependencies: Set<String> = [], sourceFiles: [SourceFile]) {
         self.target = target
         self.missingDependencies = missingDependencies
         self.unusedDependencies = unusedDependencies
         self.correctDependencies = correctDependencies
+        self.productSatisfiedDependencies = productSatisfiedDependencies
+        self.redundantDirectDependencies = redundantDirectDependencies
         self.sourceFiles = sourceFiles
     }
 }
@@ -113,12 +177,28 @@ public struct PackageAnalysis: Sendable, Codable {
         public let missingDependencies: [String]
         public let unusedDependencies: [String]
         public let correctDependencies: [String]
+        public let productSatisfiedDependencies: [ProductSatisfiedDependencyInfo]
+        public let redundantDirectDependencies: [String]
         
         public init(from result: AnalysisResult) {
             self.name = result.target.name
             self.missingDependencies = Array(result.missingDependencies).sorted()
             self.unusedDependencies = Array(result.unusedDependencies).sorted()
             self.correctDependencies = Array(result.correctDependencies).sorted()
+            self.productSatisfiedDependencies = result.productSatisfiedDependencies.map { ProductSatisfiedDependencyInfo(from: $0) }.sorted { $0.importName < $1.importName }
+            self.redundantDirectDependencies = Array(result.redundantDirectDependencies).sorted()
+        }
+    }
+    
+    public struct ProductSatisfiedDependencyInfo: Sendable, Codable {
+        public let importName: String
+        public let productName: String
+        public let packageName: String
+        
+        public init(from dependency: ProductSatisfiedDependency) {
+            self.importName = dependency.importName
+            self.productName = dependency.productName
+            self.packageName = dependency.packageName
         }
     }
 }

--- a/Sources/SwiftDependencyAuditLib/PackageParser.swift
+++ b/Sources/SwiftDependencyAuditLib/PackageParser.swift
@@ -937,8 +937,6 @@ public actor PackageParser {
     private func parseProductsFromSection(_ productsSection: String, packageName: String) -> [Product] {
         var products: [Product] = []
         
-        // Product declaration pattern using RegexBuilder (unused in this method)
-        
         // Find all product declarations
         let productDeclarations = findProductDeclarations(in: productsSection)
         

--- a/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
@@ -1,0 +1,281 @@
+import Testing
+import Foundation
+@testable import SwiftDependencyAuditLib
+
+struct ProductDependencyTests {
+    
+    @Test func testProductParsing() async throws {
+        let packageContent = """
+        // swift-tools-version: 6.1
+        import PackageDescription
+        
+        let products: [Product] = [
+            .library(name: "NetworkKit", targets: ["NetworkClient", "NetworkCore"]),
+            .library(name: "DataProcessor", targets: ["DataModels", "DataStorage"]),
+            .executable(name: "CLITool", targets: ["CLIMain"])
+        ]
+        
+        let package = Package(
+            name: "ExamplePackage",
+            products: products,
+            targets: []
+        )
+        """
+        
+        let parser = PackageParser()
+        let packageInfo = try await parser.parseContent(packageContent, packageDirectory: "/tmp/test")
+        
+        #expect(packageInfo.products.count == 3)
+        
+        let networkKit = packageInfo.products.first { $0.name == "NetworkKit" }
+        #expect(networkKit != nil)
+        #expect(networkKit?.type == .library)
+        #expect(networkKit?.targets == ["NetworkClient", "NetworkCore"])
+        
+        let dataProcessor = packageInfo.products.first { $0.name == "DataProcessor" }
+        #expect(dataProcessor != nil)
+        #expect(dataProcessor?.type == .library)
+        #expect(dataProcessor?.targets == ["DataModels", "DataStorage"])
+        
+        let cliTool = packageInfo.products.first { $0.name == "CLITool" }
+        #expect(cliTool != nil)
+        #expect(cliTool?.type == .executable)
+        #expect(cliTool?.targets == ["CLIMain"])
+    }
+    
+    @Test func testExternalDependencyParsing() async throws {
+        let packageContent = """
+        // swift-tools-version: 6.1
+        import PackageDescription
+        
+        let dependencies: [Package.Dependency] = [
+            .package(url: "https://github.com/example/swift-algorithms.git", exact: "1.2.0"),
+            .package(path: "../UtilityLibrary"),
+            .package(url: "https://github.com/example/networking-kit.git", exact: "2.1.0")
+        ]
+        
+        let package = Package(
+            name: "TestPackage",
+            dependencies: dependencies,
+            targets: []
+        )
+        """
+        
+        let parser = PackageParser()
+        let packageInfo = try await parser.parseContent(packageContent, packageDirectory: "/tmp/test")
+        
+        #expect(packageInfo.externalDependencies.count == 3)
+        
+        let algorithms = packageInfo.externalDependencies.first { $0.packageName == "swift-algorithms" }
+        #expect(algorithms != nil)
+        #expect(algorithms?.url == "https://github.com/example/swift-algorithms.git")
+        
+        let utility = packageInfo.externalDependencies.first { $0.packageName == "UtilityLibrary" }
+        #expect(utility != nil)
+        #expect(utility?.path == "../UtilityLibrary")
+        
+        let networking = packageInfo.externalDependencies.first { $0.packageName == "networking-kit" }
+        #expect(networking != nil)
+        #expect(networking?.url == "https://github.com/example/networking-kit.git")
+    }
+    
+    @Test func testProductToTargetMapping() async throws {
+        let externalPackages = [
+            ExternalPackage(
+                name: "UtilityLibrary",
+                products: [
+                    Product(name: "CoreUtilities", type: .library, targets: ["StringUtils", "DateUtils"], packageName: "UtilityLibrary"),
+                    Product(name: "NetworkUtilities", type: .library, targets: ["HTTPClient", "WebSocket"], packageName: "UtilityLibrary")
+                ],
+                path: "/tmp/UtilityLibrary"
+            ),
+            ExternalPackage(
+                name: "DataKit",
+                products: [
+                    Product(name: "DataModels", type: .library, targets: ["Models", "Validators"], packageName: "DataKit")
+                ],
+                path: "/tmp/DataKit"
+            )
+        ]
+        
+        let resolver = ExternalPackageResolver()
+        let mapping = await resolver.buildProductToTargetMapping(from: externalPackages)
+        
+        #expect(mapping.count == 3)
+        #expect(mapping["CoreUtilities"] == ["StringUtils", "DateUtils"])
+        #expect(mapping["NetworkUtilities"] == ["HTTPClient", "WebSocket"])
+        #expect(mapping["DataModels"] == ["Models", "Validators"])
+    }
+    
+    @Test func testProductSatisfiedDependencyDetection() async throws {
+        // Create a target that imports "StringUtils" and has a product dependency on "CoreUtilities"
+        let target = Target(
+            name: "TestTarget",
+            type: .library,
+            dependencies: ["CoreUtilities", "SomeOtherDep"], // Product dependency
+            path: nil
+        )
+        
+        let packageInfo = PackageInfo(
+            name: "TestPackage",
+            targets: [target],
+            dependencies: [],
+            path: "/tmp/test"
+        )
+        
+        // Mock external packages
+        let externalPackages = [
+            ExternalPackage(
+                name: "UtilityLibrary",
+                products: [
+                    Product(name: "CoreUtilities", type: .library, targets: ["StringUtils", "DateUtils"], packageName: "UtilityLibrary")
+                ],
+                path: "/tmp/UtilityLibrary"
+            )
+        ]
+        
+        let productToTargetMapping = ["CoreUtilities": ["StringUtils", "DateUtils"]]
+        
+        // Mock source files with imports
+        let sourceFiles = [
+            SourceFile(path: "/tmp/test/file1.swift", imports: [
+                ImportInfo(moduleName: "StringUtils", lineNumber: 1),
+                ImportInfo(moduleName: "SomeOtherDep", lineNumber: 2)
+            ])
+        ]
+        
+        let analyzer = DependencyAnalyzer()
+        let result = await analyzer.analyzeWithProductSupport(
+            target: target,
+            allImports: Set(["StringUtils", "SomeOtherDep"]),
+            packageInfo: packageInfo,
+            externalPackages: externalPackages,
+            productToTargetMapping: productToTargetMapping,
+            sourceFiles: sourceFiles
+        )
+        
+        // StringUtils should be detected as product-satisfied
+        #expect(result.productSatisfiedDependencies.count == 1)
+        #expect(result.productSatisfiedDependencies.first?.importName == "StringUtils")
+        #expect(result.productSatisfiedDependencies.first?.productName == "CoreUtilities")
+        #expect(result.productSatisfiedDependencies.first?.packageName == "UtilityLibrary")
+        
+        // StringUtils should not be in missing dependencies since it's satisfied by product
+        #expect(!result.missingDependencies.contains("StringUtils"))
+        
+        // SomeOtherDep should be in correct dependencies
+        #expect(result.correctDependencies.contains("SomeOtherDep"))
+    }
+    
+    @Test func testRedundantDirectDependencyDetection() async throws {
+        // Create a target with both product dependency and direct target dependency
+        let target = Target(
+            name: "TestTarget",
+            type: .library,
+            dependencies: ["CoreUtilities", "StringUtils"], // Both product and direct target
+            path: nil
+        )
+        
+        let packageInfo = PackageInfo(
+            name: "TestPackage",
+            targets: [target],
+            dependencies: [],
+            path: "/tmp/test"
+        )
+        
+        let externalPackages = [
+            ExternalPackage(
+                name: "UtilityLibrary",
+                products: [
+                    Product(name: "CoreUtilities", type: .library, targets: ["StringUtils", "DateUtils"], packageName: "UtilityLibrary")
+                ],
+                path: "/tmp/UtilityLibrary"
+            )
+        ]
+        
+        let productToTargetMapping = ["CoreUtilities": ["StringUtils", "DateUtils"]]
+        
+        let sourceFiles = [
+            SourceFile(path: "/tmp/test/file1.swift", imports: [
+                ImportInfo(moduleName: "StringUtils", lineNumber: 1)
+            ])
+        ]
+        
+        let analyzer = DependencyAnalyzer()
+        let result = await analyzer.analyzeWithProductSupport(
+            target: target,
+            allImports: Set(["StringUtils"]),
+            packageInfo: packageInfo,
+            externalPackages: externalPackages,
+            productToTargetMapping: productToTargetMapping,
+            sourceFiles: sourceFiles
+        )
+        
+        // StringUtils should be detected as redundant since it's covered by CoreUtilities
+        #expect(result.redundantDirectDependencies.contains("StringUtils"))
+        
+        // StringUtils should be detected as product-satisfied
+        #expect(result.productSatisfiedDependencies.count == 1)
+        #expect(result.productSatisfiedDependencies.first?.importName == "StringUtils")
+        #expect(result.productSatisfiedDependencies.first?.productName == "CoreUtilities")
+    }
+    
+    @Test func testMixedProductAndDirectDependencies() async throws {
+        let target = Target(
+            name: "TestTarget",
+            type: .library,
+            dependencies: ["CoreUtilities", "IndependentLibrary"],
+            path: nil
+        )
+        
+        let packageInfo = PackageInfo(
+            name: "TestPackage",
+            targets: [target],
+            dependencies: [],
+            path: "/tmp/test"
+        )
+        
+        let externalPackages = [
+            ExternalPackage(
+                name: "UtilityLibrary",
+                products: [
+                    Product(name: "CoreUtilities", type: .library, targets: ["StringUtils", "DateUtils"], packageName: "UtilityLibrary")
+                ],
+                path: "/tmp/UtilityLibrary"
+            )
+        ]
+        
+        let productToTargetMapping = ["CoreUtilities": ["StringUtils", "DateUtils"]]
+        
+        let sourceFiles = [
+            SourceFile(path: "/tmp/test/file1.swift", imports: [
+                ImportInfo(moduleName: "StringUtils", lineNumber: 1),     // Satisfied by product
+                ImportInfo(moduleName: "IndependentLibrary", lineNumber: 2), // Direct dependency
+                ImportInfo(moduleName: "MissingDep", lineNumber: 3)       // Missing
+            ])
+        ]
+        
+        let analyzer = DependencyAnalyzer()
+        let result = await analyzer.analyzeWithProductSupport(
+            target: target,
+            allImports: Set(["StringUtils", "IndependentLibrary", "MissingDep"]),
+            packageInfo: packageInfo,
+            externalPackages: externalPackages,
+            productToTargetMapping: productToTargetMapping,
+            sourceFiles: sourceFiles
+        )
+        
+        // StringUtils should be product-satisfied
+        #expect(result.productSatisfiedDependencies.count == 1)
+        #expect(result.productSatisfiedDependencies.first?.importName == "StringUtils")
+        
+        // IndependentLibrary should be correct
+        #expect(result.correctDependencies.contains("IndependentLibrary"))
+        
+        // MissingDep should be missing
+        #expect(result.missingDependencies.contains("MissingDep"))
+        
+        // No redundant dependencies in this case
+        #expect(result.redundantDirectDependencies.isEmpty)
+    }
+}

--- a/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
@@ -218,7 +218,7 @@ struct ProductDependencyTests {
         )
         
         // StringUtils should be detected as redundant since it's covered by CoreUtilities
-        #expect(result.redundantDirectDependencies.contains { $0.targetName == "StringUtils" })
+        #expect(result.redundantDirectDependencies.contains(where: { $0.targetName == "StringUtils" }))
         
         // StringUtils should be detected as product-satisfied
         #expect(result.productSatisfiedDependencies.count == 1)

--- a/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
@@ -212,7 +212,7 @@ struct ProductDependencyTests {
         )
         
         // StringUtils should be detected as redundant since it's covered by CoreUtilities
-        #expect(result.redundantDirectDependencies.contains("StringUtils"))
+        #expect(result.redundantDirectDependencies.contains { $0.targetName == "StringUtils" })
         
         // StringUtils should be detected as product-satisfied
         #expect(result.productSatisfiedDependencies.count == 1)


### PR DESCRIPTION
- Detect imports satisfied by external package products to prevent false missing dependency reports
- Identify redundant direct target dependencies covered by products
- Parse external packages from .build/checkouts after swift resolve
- Enhanced verbose reporting with product-to-target mappings
- Added comprehensive test suite with 6 new tests
- Maintains full backward compatibility with existing functionality

Resolves issue where targets importing individual modules from multi-target products incorrectly flagged those imports as missing dependencies.