### PR TITLE
Fix result generation for targets with custom paths

### DIFF
--- a/Sources/SwiftDependencyAuditLib/DependencyAnalyzer.swift
+++ b/Sources/SwiftDependencyAuditLib/DependencyAnalyzer.swift
@@ -22,7 +22,11 @@ public actor DependencyAnalyzer {
 
         // Scan source files for imports
         let sourceFiles = try await importScanner.scanDirectory(
-            at: packageInfo.path, targetName: target.name, customWhitelist: customWhitelist)
+            at: packageInfo.path,
+            targetName: target.name,
+            targetPathOverride: target.path,
+            customWhitelist: customWhitelist
+        )
 
         // Collect all unique imports from source files
         var allImports = Set<String>()

--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -82,7 +82,7 @@ public actor ImportScanner {
         let fileManager = FileManager.default
 
         var sourcePath: URL
-        // If a custom path overide is provided use that for the source path, othereise use the standard path name based on target name
+        // If a custom path override is provided, use that for the source path. Otherwise, use the standard path name based on target name.
         if let targetPathOverride {
             sourcePath = URL(fileURLWithPath: path).appendingPathComponent(targetPathOverride)
         } else {

--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -73,17 +73,28 @@ public actor ImportScanner {
         return imports
     }
 
-    public func scanDirectory(at path: String, targetName: String, customWhitelist: Set<String> = []) async throws
-        -> [SourceFile]
-    {
+    public func scanDirectory(
+        at path: String,
+        targetName: String,
+        targetPathOverride: String?,
+        customWhitelist: Set<String> = []
+    ) async throws -> [SourceFile] {
         let fileManager = FileManager.default
 
-        // Try Sources directory first
-        var sourcePath = URL(fileURLWithPath: path).appendingPathComponent("Sources").appendingPathComponent(targetName)
+        var sourcePath: URL
+        // If a custom path overide is provided use that for the source path, othereise use the standard path name based on target name
+        if let targetPathOverride {
+            sourcePath = URL(fileURLWithPath: path).appendingPathComponent(targetPathOverride)
+        } else {
+            // Try Sources directory first
+            sourcePath = URL(fileURLWithPath: path).appendingPathComponent("Sources").appendingPathComponent(targetName)
 
-        // If not found in Sources, try Tests directory for test targets
-        if !fileManager.fileExists(atPath: sourcePath.path) {
-            sourcePath = URL(fileURLWithPath: path).appendingPathComponent("Tests").appendingPathComponent(targetName)
+            // If not found in Sources, try Tests directory for test targets
+            if !fileManager.fileExists(atPath: sourcePath.path) {
+                sourcePath = URL(fileURLWithPath: path)
+                    .appendingPathComponent("Tests")
+                    .appendingPathComponent(targetName)
+            }
         }
 
         guard fileManager.fileExists(atPath: sourcePath.path) else {

--- a/Tests/SwiftDependencyAuditTests/IntegrationTests.swift
+++ b/Tests/SwiftDependencyAuditTests/IntegrationTests.swift
@@ -179,11 +179,11 @@ struct IntegrationTests {
         try "import ArgumentParser\nprint(\"Hello\")".write(
             to: mainDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
 
-      // Create with custom path
-      let customPathDir = tempDir.appendingPathComponent("Sources/MyCustomPath")
-      try FileManager.default.createDirectory(at: customPathDir, withIntermediateDirectories: true)
-      try "import ArgumentParser\nprint(\"Hello\")".write(
-        to: customPathDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
+        // Create with custom path
+        let customPathDir = tempDir.appendingPathComponent("Sources/MyCustomPath")
+        try FileManager.default.createDirectory(at: customPathDir, withIntermediateDirectories: true)
+        try "import ArgumentParser\nprint(\"Hello\")".write(
+            to: customPathDir.appendingPathComponent("main.swift"), atomically: true, encoding: .utf8)
 
         // Create test target with missing dependency
         let testDir = tempDir.appendingPathComponent("Tests/TestPackageTests")

--- a/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
+++ b/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
@@ -135,11 +135,11 @@ struct PackageParserTests {
         #expect(packageInfo.name == "My-Special_Package123")
     }
 
-  @Test("Parse package name with custom path")
-  func testPackagePathParsing() async throws {
-    let packageContent = """
+    @Test("Parse package name with custom path")
+    func testPackagePathParsing() async throws {
+        let packageContent = """
             import PackageDescription
-            
+
             let package = Package(
                 name: "MyCustomPathPackage",
                 targets: [
@@ -152,21 +152,21 @@ struct PackageParserTests {
             )
             """
 
-    let tempDir = FileManager.default.temporaryDirectory
-    let packageDir = tempDir.appendingPathComponent("SpecialPackage_\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("SpecialPackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
 
-    let packageFile = packageDir.appendingPathComponent("Package.swift")
-    try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
 
-    defer {
-      try? FileManager.default.removeItem(at: packageDir)
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        let libTarget = packageInfo.targets.first { $0.name == "LibraryTarget" }
+        #expect(libTarget?.path == "/Sources/MyCustomPath")
     }
-
-    let parser = PackageParser()
-    let packageInfo = try await parser.parsePackage(at: packageDir.path)
-
-    let libTarget = packageInfo.targets.first { $0.name == "LibraryTarget" }
-    #expect(libTarget?.path == "/Sources/MyCustomPath")
-  }
 }


### PR DESCRIPTION
# The Issue

While trying out the tool at the joby-job I noticed some inconsistent output. For some targets we knew had errors no errors would be output in the report. Additionally in verbose mode some targets wouldn't be included in the report. This turned out to be an issue with any target that used a custom path.

The issue turned out to by caused by `scanDirectory` function in `ImportScanner` not using the path property from the `Target` object. It was always attempting to use the standard `/Sources/[TargetName]` or `/Tests/[TestTargetName]` format. This would result in `scanDirectory` not finding the target files and throwing a `ScannerError.sourceDirectoryNotFound` error. This would then skip checking the target and not included it in the report.

# The Fix

The fix was to add a parameter to the `scanDirectory` function, `targetPathOverride`. This parameter is an optional `String`. If it's provided the file lookup will be done at that path, otherwise the existing default location behaviors will be used.