### PR TITLE
Add support for dependency constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,8 @@ jobs:
           echo "=== Format Check ==="
           # Use the built-in swift format command from the Swift toolchain
           swift format --version
-          swift format lint --recursive --strict .
+          # Check all Swift files except test fixtures and build artifacts
+          find . -name "*.swift" -not -path "./.build/*" -not -path "./Tests/*/Fixtures/*" | xargs swift format lint --strict
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Constant-Based Dependency Declarations**
   - Support for dependency constants like `private let TCA = Target.Dependency.product(name: "ComposableArchitecture", package: "swift-composable-architecture")`
   - Resolves constant references in dependency arrays (e.g., `dependencies: [TCA]`)
-  - Works with all access levels (`private`, `public`, `internal`, `fileprivate`)
+  - Works with all Swift access levels (`private`, `fileprivate`, `internal`, `public`, `open`)
   - Maintains full backward compatibility with existing dependency declaration methods
+
+### Fixed
+- **Missing Access Modifier Support**
+  - Added support for `open` access modifier in dependency constants
+  - Fixed parsing of dependency constants without explicit access modifiers (defaults to `internal`)
 
 ## [v1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Constant-Based Dependency Declarations**
+  - Support for dependency constants like `private let TCA = Target.Dependency.product(name: "ComposableArchitecture", package: "swift-composable-architecture")`
+  - Resolves constant references in dependency arrays (e.g., `dependencies: [TCA]`)
+  - Works with all access levels (`private`, `public`, `internal`, `fileprivate`)
+  - Maintains full backward compatibility with existing dependency declaration methods
+
 ## [v1.4.0]
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,4 @@ See PROJECT_PLAN.md for detailed implementation phases and technical specificati
 ## Claude Memories
 
 - It's 2025, stop appending 2024 to your searches.
+- Don't embed Package.swift test fixtures inside the test source files. Please add them to the Fixtures directory that already exists and access them from there within the tests.

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,8 @@ let package = Package(
         ),
         .testTarget(
             name: "SwiftDependencyAuditTests",
-            dependencies: ["SwiftDependencyAuditLib"]
+            dependencies: ["SwiftDependencyAuditLib"],
+            resources: [.copy("Fixtures")]
         ),
         .plugin(
             name: "DependencyAuditPlugin",

--- a/Sources/SwiftDependencyAuditLib/PackageParser.swift
+++ b/Sources/SwiftDependencyAuditLib/PackageParser.swift
@@ -406,14 +406,15 @@ public actor PackageParser {
     // Build a dictionary of all dependency constants in the package for quick lookup
     private func buildDependencyConstantsMap(from content: String) -> [String: DependencyInfo] {
         var constantsMap: [String: DependencyInfo] = [:]
-        
+
         for match in content.matches(of: dependencyConstantPattern) {
             let varName = String(match.1)
             let productName = String(match.2)
             let packageName = String(match.3)
-            constantsMap[varName] = DependencyInfo(name: productName, type: .product(packageName: packageName), lineNumber: nil)
+            constantsMap[varName] = DependencyInfo(
+                name: productName, type: .product(packageName: packageName), lineNumber: nil)
         }
-        
+
         return constantsMap
     }
 
@@ -870,21 +871,23 @@ public actor PackageParser {
         let components = dependenciesStr.components(separatedBy: ",")
         for component in components {
             let trimmed = component.trimmingCharacters(in: .whitespacesAndNewlines)
-            
+
             // Check for constant references (identifiers without quotes)
             if !trimmed.hasPrefix("\"") && !trimmed.contains(".product") && !trimmed.isEmpty {
                 // Remove any trailing comments or commas
-                let constantName = trimmed.components(separatedBy: CharacterSet(charactersIn: " \t\n,")).first ?? trimmed
-                
+                let constantName =
+                    trimmed.components(separatedBy: CharacterSet(charactersIn: " \t\n,")).first ?? trimmed
+
                 if let constantInfo = constantsMap[constantName] {
                     // Found a dependency constant - resolve it to the actual dependency
                     let lineNumber = findConstantLineNumber(
                         constantName: constantName, targetName: targetName, in: packageContent)
-                    let resolvedInfo = DependencyInfo(name: constantInfo.name, type: constantInfo.type, lineNumber: lineNumber)
+                    let resolvedInfo = DependencyInfo(
+                        name: constantInfo.name, type: constantInfo.type, lineNumber: lineNumber)
                     dependencyInfos.append(resolvedInfo)
                 }
             }
-            // Match simple quoted strings that aren't part of .product() calls  
+            // Match simple quoted strings that aren't part of .product() calls
             else if trimmed.hasPrefix("\"") && trimmed.hasSuffix("\"") && !trimmed.contains(".product") {
                 let quoted = String(trimmed.dropFirst().dropLast())
                 let lineNumber = findDependencyLineNumber(

--- a/Sources/SwiftDependencyAuditLib/PackageParser.swift
+++ b/Sources/SwiftDependencyAuditLib/PackageParser.swift
@@ -133,13 +133,16 @@ public actor PackageParser {
     // private let TCA = Target.Dependency.product(name: "ComposableArchitecture", package: "swift-composable-architecture")
     private var dependencyConstantPattern: Regex<(Substring, Substring, Substring, Substring)> {
         Regex {
-            ChoiceOf {
-                "private"
-                "public"
-                "internal"
-                "fileprivate"
+            Optionally {
+                ChoiceOf {
+                    "private"
+                    "fileprivate"
+                    "internal"
+                    "public"
+                    "open"
+                }
+                OneOrMore(.whitespace)
             }
-            OneOrMore(.whitespace)
             "let"
             OneOrMore(.whitespace)
             Capture {
@@ -176,7 +179,11 @@ public actor PackageParser {
             ZeroOrMore(.whitespace)
             ChoiceOf {
                 ")"
-                ",)"
+                Regex {
+                    ","
+                    ZeroOrMore(.any)
+                    ")"
+                }
             }
         }
         .dotMatchesNewlines()

--- a/Tests/SwiftDependencyAuditTests/Fixtures/BasicPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/BasicPackage.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TestPackage",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "TestTarget",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/CompleteTestPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/CompleteTestPackage.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TestPackage",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "TestPackage",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+        .target(
+            name: "CustomPathTarget",
+            dependencies: [],
+            path: "/Sources/MyCustomPath"
+        ),
+        .testTarget(
+            name: "TestPackageTests",
+            dependencies: ["TestPackage"]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ComplexPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ComplexPackage.swift
@@ -1,0 +1,20 @@
+import PackageDescription
+
+let package = Package(
+    name: "ComplexPackage",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "MyLibrary",
+            dependencies: [
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ]
+        ),
+        .executableTarget(
+            name: "MyApp",
+            dependencies: ["MyLibrary"]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ConditionalPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ConditionalPackage.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+// Constant with condition parameter (realistic use case)
+private let iOSOnlyDep = Target.Dependency.product(
+    name: "iOSFramework",
+    package: "ios-framework",
+    condition: .when(platforms: [.iOS])
+)
+
+let package = Package(
+    name: "ConditionalPackage",
+    dependencies: [
+        .package(url: "https://github.com/example/ios-framework", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "ConditionalTarget",
+            dependencies: [
+                iOSOnlyDep,
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ConstantDepsPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ConstantDepsPackage.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+private let TCA = Target.Dependency.product(
+    name: "ComposableArchitecture",
+    package: "swift-composable-architecture"
+)
+
+private let AsyncAlgorithms = Target.Dependency.product(
+    name: "AsyncAlgorithms",
+    package: "swift-async-algorithms"
+)
+
+let package = Package(
+    name: "ConstantDepsPackage",
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "MyFeature",
+            dependencies: [
+                TCA,
+                AsyncAlgorithms
+            ]
+        ),
+        .testTarget(
+            name: "MyFeatureTests",
+            dependencies: [
+                "MyFeature",
+                TCA
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ConstantDepsPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ConstantDepsPackage.swift
@@ -15,22 +15,22 @@ let package = Package(
     name: "ConstantDepsPackage",
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "MyFeature",
             dependencies: [
                 TCA,
-                AsyncAlgorithms
+                AsyncAlgorithms,
             ]
         ),
         .testTarget(
             name: "MyFeatureTests",
             dependencies: [
                 "MyFeature",
-                TCA
+                TCA,
             ]
-        )
+        ),
     ]
 )

--- a/Tests/SwiftDependencyAuditTests/Fixtures/CustomPathPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/CustomPathPackage.swift
@@ -1,0 +1,12 @@
+import PackageDescription
+
+let package = Package(
+    name: "MyCustomPathPackage",
+    targets: [
+        .target(
+            name: "LibraryTarget",
+            dependencies: ["Dep1"],
+            path: "/Sources/MyCustomPath"
+        ),
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/EdgeCasePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/EdgeCasePackage.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+// Constant with different formatting (minimal spaces)
+let CompactDep = Target.Dependency.product(name: "Compact", package: "compact-package")
+
+// Standard dependencies mixed with constants
+let package = Package(
+    name: "EdgeCasePackage",
+    dependencies: [
+        .package(url: "https://github.com/example/compact-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/standard-package", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "EdgeTarget",
+            dependencies: [
+                CompactDep,
+                .product(name: "StandardProduct", package: "standard-package"),
+                "LocalTarget",
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ExternalDependencyPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ExternalDependencyPackage.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/example/swift-algorithms.git", exact: "1.2.0"),
+    .package(path: "../UtilityLibrary"),
+    .package(url: "https://github.com/example/networking-kit.git", exact: "2.1.0")
+]
+
+let package = Package(
+    name: "TestPackage",
+    dependencies: dependencies,
+    targets: []
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/LargePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/LargePackage.swift
@@ -1,0 +1,8 @@
+import PackageDescription
+
+let package = Package(
+    name: "LargePackage",
+    targets: [
+        .target(name: "LargeTarget", dependencies: [])
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/MixedAccessPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/MixedAccessPackage.swift
@@ -1,0 +1,57 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+private let PrivateDep = Target.Dependency.product(
+    name: "Private",
+    package: "private-package"
+)
+
+public let PublicDep = Target.Dependency.product(
+    name: "Public",
+    package: "public-package"
+)
+
+internal let InternalDep = Target.Dependency.product(
+    name: "Internal",
+    package: "internal-package"
+)
+
+fileprivate let FileprivateDep = Target.Dependency.product(
+    name: "Fileprivate",
+    package: "fileprivate-package"
+)
+
+open let OpenDep = Target.Dependency.product(
+    name: "Open",
+    package: "open-package"
+)
+
+let NoModifierDep = Target.Dependency.product(
+    name: "NoModifier",
+    package: "no-modifier-package"
+)
+
+let package = Package(
+    name: "MixedAccessPackage",
+    dependencies: [
+        .package(url: "https://github.com/example/private-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/public-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/internal-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/fileprivate-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/open-package", from: "1.0.0"),
+        .package(url: "https://github.com/example/no-modifier-package", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "MixedTarget",
+            dependencies: [
+                PrivateDep,
+                FileprivateDep,
+                InternalDep,
+                PublicDep,
+                OpenDep,
+                NoModifierDep,
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/MixedStylePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/MixedStylePackage.swift
@@ -9,7 +9,7 @@ let package = Package(
     name: "MixedStylePackage",
     dependencies: [
         .package(url: "https://github.com/example/custom-framework", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -17,7 +17,7 @@ let package = Package(
             dependencies: [
                 CustomDep,
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                "InternalDependency"
+                "InternalDependency",
             ]
         )
     ]

--- a/Tests/SwiftDependencyAuditTests/Fixtures/MixedStylePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/MixedStylePackage.swift
@@ -1,0 +1,24 @@
+import PackageDescription
+
+private let CustomDep = Target.Dependency.product(
+    name: "CustomFramework",
+    package: "custom-framework"
+)
+
+let package = Package(
+    name: "MixedStylePackage",
+    dependencies: [
+        .package(url: "https://github.com/example/custom-framework", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
+    ],
+    targets: [
+        .target(
+            name: "MainTarget",
+            dependencies: [
+                CustomDep,
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                "InternalDependency"
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/MultiTargetPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/MultiTargetPackage.swift
@@ -1,0 +1,10 @@
+import PackageDescription
+
+let package = Package(
+    name: "MultiTargetPackage",
+    targets: [
+        .target(name: "LibraryTarget", dependencies: ["Dep1"]),
+        .executableTarget(name: "ExecutableTarget", dependencies: ["LibraryTarget"]),
+        .testTarget(name: "TestTarget", dependencies: ["LibraryTarget"])
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/NoAccessModifierPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/NoAccessModifierPackage.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let TCA = Target.Dependency.product(
+    name: "ComposableArchitecture",
+    package: "swift-composable-architecture"
+)
+
+let AsyncAlgorithms = Target.Dependency.product(
+    name: "AsyncAlgorithms",
+    package: "swift-async-algorithms"
+)
+
+let package = Package(
+    name: "NoAccessModifierPackage",
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "MyTarget",
+            dependencies: [
+                TCA,
+                AsyncAlgorithms,
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/OpenAccessPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/OpenAccessPackage.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+open let OpenDep = Target.Dependency.product(
+    name: "OpenFramework",
+    package: "open-package"
+)
+
+let package = Package(
+    name: "OpenAccessPackage",
+    dependencies: [
+        .package(url: "https://github.com/example/open-package", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "OpenTarget",
+            dependencies: [
+                OpenDep,
+            ]
+        )
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ProductTestPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ProductTestPackage.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let products: [Product] = [
+    .library(name: "NetworkKit", targets: ["NetworkClient", "NetworkCore"]),
+    .library(name: "DataProcessor", targets: ["DataModels", "DataStorage"]),
+    .executable(name: "CLITool", targets: ["CLIMain"])
+]
+
+let package = Package(
+    name: "ExamplePackage",
+    products: products,
+    targets: []
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/SimplePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/SimplePackage.swift
@@ -1,0 +1,8 @@
+import PackageDescription
+
+let package = Package(
+    name: "SimplePackage",
+    targets: [
+        .target(name: "SimpleTarget", dependencies: [])
+    ]
+)

--- a/Tests/SwiftDependencyAuditTests/Fixtures/SpecialNamePackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/SpecialNamePackage.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "My-Special_Package123",
+    targets: []
+)

--- a/Tests/SwiftDependencyAuditTests/IntegrationTests.swift
+++ b/Tests/SwiftDependencyAuditTests/IntegrationTests.swift
@@ -142,34 +142,10 @@ struct IntegrationTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
         // Create Package.swift
-        let packageContent = """
-            // swift-tools-version: 6.0
-            import PackageDescription
-
-            let package = Package(
-                name: "TestPackage",
-                dependencies: [
-                    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
-                ],
-                targets: [
-                    .executableTarget(
-                        name: "TestPackage",
-                        dependencies: [
-                            .product(name: "ArgumentParser", package: "swift-argument-parser")
-                        ]
-                    ),
-                    .target(
-                        name: "CustomPathTarget",
-                        dependencies: [],
-                        path: "/Sources/MyCustomPath"
-                    ),
-                    .testTarget(
-                        name: "TestPackageTests",
-                        dependencies: ["TestPackage"]
-                    )
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "CompleteTestPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         try packageContent.write(to: tempDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
 
@@ -199,28 +175,10 @@ struct IntegrationTests {
             "ComplexPackage_\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "ComplexPackage",
-                dependencies: [
-                    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
-                ],
-                targets: [
-                    .target(
-                        name: "MyLibrary",
-                        dependencies: [
-                            .product(name: "ArgumentParser", package: "swift-argument-parser")
-                        ]
-                    ),
-                    .executableTarget(
-                        name: "MyApp",
-                        dependencies: ["MyLibrary"]
-                    )
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "ComplexPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         try packageContent.write(to: tempDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
 
@@ -244,16 +202,10 @@ struct IntegrationTests {
             "SimplePackage_\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "SimplePackage",
-                targets: [
-                    .target(name: "SimpleTarget", dependencies: [])
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "SimplePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         try packageContent.write(to: tempDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
 
@@ -269,16 +221,10 @@ struct IntegrationTests {
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("LargePackage_\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
 
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "LargePackage",
-                targets: [
-                    .target(name: "LargeTarget", dependencies: [])
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "LargePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         try packageContent.write(to: tempDir.appendingPathComponent("Package.swift"), atomically: true, encoding: .utf8)
 

--- a/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
+++ b/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
@@ -172,44 +172,9 @@ struct PackageParserTests {
 
     @Test("Parse package with constant-based dependencies")
     func testConstantBasedDependencies() async throws {
-        let packageContent = """
-            // swift-tools-version: 6.0
-            import PackageDescription
-
-            private let TCA = Target.Dependency.product(
-                name: "ComposableArchitecture",
-                package: "swift-composable-architecture"
-            )
-            
-            private let AsyncAlgorithms = Target.Dependency.product(
-                name: "AsyncAlgorithms",
-                package: "swift-async-algorithms"
-            )
-
-            let package = Package(
-                name: "ConstantDepsPackage",
-                dependencies: [
-                    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "1.0.0"),
-                    .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0")
-                ],
-                targets: [
-                    .target(
-                        name: "MyFeature",
-                        dependencies: [
-                            TCA,
-                            AsyncAlgorithms
-                        ]
-                    ),
-                    .testTarget(
-                        name: "MyFeatureTests",
-                        dependencies: [
-                            "MyFeature",
-                            TCA
-                        ]
-                    )
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(forResource: "ConstantDepsPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
         let packageDir = tempDir.appendingPathComponent("ConstantDepsPackage_\(UUID().uuidString)")
@@ -247,32 +212,9 @@ struct PackageParserTests {
 
     @Test("Parse package with mixed dependency styles")
     func testMixedDependencyStyles() async throws {
-        let packageContent = """
-            import PackageDescription
-
-            private let CustomDep = Target.Dependency.product(
-                name: "CustomFramework",
-                package: "custom-framework"
-            )
-
-            let package = Package(
-                name: "MixedStylePackage",
-                dependencies: [
-                    .package(url: "https://github.com/example/custom-framework", from: "1.0.0"),
-                    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
-                ],
-                targets: [
-                    .target(
-                        name: "MainTarget",
-                        dependencies: [
-                            CustomDep,
-                            .product(name: "ArgumentParser", package: "swift-argument-parser"),
-                            "InternalDependency"
-                        ]
-                    )
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(forResource: "MixedStylePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
         let packageDir = tempDir.appendingPathComponent("MixedStylePackage_\(UUID().uuidString)")

--- a/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
+++ b/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
@@ -242,4 +242,162 @@ struct PackageParserTests {
         #expect(mainTarget?.dependencies.contains("ArgumentParser") == true)
         #expect(mainTarget?.dependencies.contains("InternalDependency") == true)
     }
+
+    @Test("Parse package with constants without access modifiers")
+    func testConstantsWithoutAccessModifiers() async throws {
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "NoAccessModifierPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("NoAccessModifierPackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        #expect(packageInfo.name == "NoAccessModifierPackage")
+        #expect(packageInfo.targets.count == 1)
+
+        let myTarget = packageInfo.targets.first
+        #expect(myTarget?.name == "MyTarget")
+        #expect(myTarget?.dependencies.count == 2)
+        #expect(myTarget?.dependencies.contains("ComposableArchitecture") == true)
+        #expect(myTarget?.dependencies.contains("AsyncAlgorithms") == true)
+    }
+
+    @Test("Parse package with mixed access modifier styles")
+    func testMixedAccessModifierStyles() async throws {
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "MixedAccessPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("MixedAccessPackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        #expect(packageInfo.name == "MixedAccessPackage")
+        #expect(packageInfo.targets.count == 1)
+
+        let mixedTarget = packageInfo.targets.first
+        #expect(mixedTarget?.name == "MixedTarget")
+        #expect(mixedTarget?.dependencies.count == 6)
+        #expect(mixedTarget?.dependencies.contains("Private") == true)
+        #expect(mixedTarget?.dependencies.contains("Fileprivate") == true)
+        #expect(mixedTarget?.dependencies.contains("Internal") == true)
+        #expect(mixedTarget?.dependencies.contains("Public") == true)
+        #expect(mixedTarget?.dependencies.contains("Open") == true)
+        #expect(mixedTarget?.dependencies.contains("NoModifier") == true)
+    }
+
+    @Test("Parse package with edge cases in constant parsing")
+    func testConstantParsingEdgeCases() async throws {
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "EdgeCasePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("EdgeCasePackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        #expect(packageInfo.name == "EdgeCasePackage")
+        #expect(packageInfo.targets.count == 1)
+
+        let edgeTarget = packageInfo.targets.first
+        #expect(edgeTarget?.name == "EdgeTarget")
+        #expect(edgeTarget?.dependencies.count == 3)
+        #expect(edgeTarget?.dependencies.contains("Compact") == true)
+        #expect(edgeTarget?.dependencies.contains("StandardProduct") == true)
+        #expect(edgeTarget?.dependencies.contains("LocalTarget") == true)
+    }
+
+    @Test("Parse package with constants having extra parameters")
+    func testConstantsWithExtraParameters() async throws {
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "ConditionalPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("ConditionalPackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        #expect(packageInfo.name == "ConditionalPackage")
+        #expect(packageInfo.targets.count == 1)
+
+        let conditionalTarget = packageInfo.targets.first
+        #expect(conditionalTarget?.name == "ConditionalTarget")
+        #expect(conditionalTarget?.dependencies.count == 1)
+        #expect(conditionalTarget?.dependencies.contains("iOSFramework") == true)
+    }
+
+    @Test("Parse package with open access modifier")
+    func testOpenAccessModifier() async throws {
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "OpenAccessPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let packageDir = tempDir.appendingPathComponent("OpenAccessPackage_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+
+        let packageFile = packageDir.appendingPathComponent("Package.swift")
+        try packageContent.write(to: packageFile, atomically: true, encoding: .utf8)
+
+        defer {
+            try? FileManager.default.removeItem(at: packageDir)
+        }
+
+        let parser = PackageParser()
+        let packageInfo = try await parser.parsePackage(at: packageDir.path)
+
+        #expect(packageInfo.name == "OpenAccessPackage")
+        #expect(packageInfo.targets.count == 1)
+
+        let openTarget = packageInfo.targets.first
+        #expect(openTarget?.name == "OpenTarget")
+        #expect(openTarget?.dependencies.count == 1)
+        #expect(openTarget?.dependencies.contains("OpenFramework") == true)
+    }
 }

--- a/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
+++ b/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
@@ -8,25 +8,10 @@ struct PackageParserTests {
 
     @Test("Parse basic Package.swift")
     func testBasicPackageParsing() async throws {
-        let packageContent = """
-            // swift-tools-version: 6.0
-            import PackageDescription
-
-            let package = Package(
-                name: "TestPackage",
-                dependencies: [
-                    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
-                ],
-                targets: [
-                    .executableTarget(
-                        name: "TestTarget",
-                        dependencies: [
-                            .product(name: "ArgumentParser", package: "swift-argument-parser")
-                        ]
-                    ),
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "BasicPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         // Create temporary file for testing
         let tempDir = FileManager.default.temporaryDirectory
@@ -52,18 +37,10 @@ struct PackageParserTests {
 
     @Test("Parse package with multiple targets")
     func testMultipleTargets() async throws {
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "MultiTargetPackage",
-                targets: [
-                    .target(name: "LibraryTarget", dependencies: ["Dep1"]),
-                    .executableTarget(name: "ExecutableTarget", dependencies: ["LibraryTarget"]),
-                    .testTarget(name: "TestTarget", dependencies: ["LibraryTarget"])
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "MultiTargetPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
         let packageDir = tempDir.appendingPathComponent("MultiTargetPackage_\(UUID().uuidString)")
@@ -109,14 +86,10 @@ struct PackageParserTests {
 
     @Test("Parse package name with special characters")
     func testPackageNameParsing() async throws {
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "My-Special_Package123",
-                targets: []
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "SpecialNamePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
         let packageDir = tempDir.appendingPathComponent("SpecialPackage_\(UUID().uuidString)")
@@ -137,20 +110,10 @@ struct PackageParserTests {
 
     @Test("Parse package name with custom path")
     func testPackagePathParsing() async throws {
-        let packageContent = """
-            import PackageDescription
-
-            let package = Package(
-                name: "MyCustomPathPackage",
-                targets: [
-                    .target(
-                        name: "LibraryTarget",
-                        dependencies: ["Dep1"],
-                        path: "/Sources/MyCustomPath"
-                    ),
-                ]
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "CustomPathPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
         let packageDir = tempDir.appendingPathComponent("SpecialPackage_\(UUID().uuidString)")

--- a/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
+++ b/Tests/SwiftDependencyAuditTests/PackageParserTests.swift
@@ -173,7 +173,8 @@ struct PackageParserTests {
     @Test("Parse package with constant-based dependencies")
     func testConstantBasedDependencies() async throws {
         let testBundle = Bundle.module
-        let fixtureURL = testBundle.url(forResource: "ConstantDepsPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let fixtureURL = testBundle.url(
+            forResource: "ConstantDepsPackage", withExtension: "swift", subdirectory: "Fixtures")!
         let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory
@@ -213,7 +214,8 @@ struct PackageParserTests {
     @Test("Parse package with mixed dependency styles")
     func testMixedDependencyStyles() async throws {
         let testBundle = Bundle.module
-        let fixtureURL = testBundle.url(forResource: "MixedStylePackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let fixtureURL = testBundle.url(
+            forResource: "MixedStylePackage", withExtension: "swift", subdirectory: "Fixtures")!
         let packageContent = try String(contentsOf: fixtureURL)
 
         let tempDir = FileManager.default.temporaryDirectory

--- a/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ProductDependencyTests.swift
@@ -6,22 +6,10 @@ import Testing
 struct ProductDependencyTests {
 
     @Test func testProductParsing() async throws {
-        let packageContent = """
-            // swift-tools-version: 6.1
-            import PackageDescription
-
-            let products: [Product] = [
-                .library(name: "NetworkKit", targets: ["NetworkClient", "NetworkCore"]),
-                .library(name: "DataProcessor", targets: ["DataModels", "DataStorage"]),
-                .executable(name: "CLITool", targets: ["CLIMain"])
-            ]
-
-            let package = Package(
-                name: "ExamplePackage",
-                products: products,
-                targets: []
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "ProductTestPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let parser = PackageParser()
         let packageInfo = try await parser.parseContent(packageContent, packageDirectory: "/tmp/test")
@@ -45,22 +33,10 @@ struct ProductDependencyTests {
     }
 
     @Test func testExternalDependencyParsing() async throws {
-        let packageContent = """
-            // swift-tools-version: 6.1
-            import PackageDescription
-
-            let dependencies: [Package.Dependency] = [
-                .package(url: "https://github.com/example/swift-algorithms.git", exact: "1.2.0"),
-                .package(path: "../UtilityLibrary"),
-                .package(url: "https://github.com/example/networking-kit.git", exact: "2.1.0")
-            ]
-
-            let package = Package(
-                name: "TestPackage",
-                dependencies: dependencies,
-                targets: []
-            )
-            """
+        let testBundle = Bundle.module
+        let fixtureURL = testBundle.url(
+            forResource: "ExternalDependencyPackage", withExtension: "swift", subdirectory: "Fixtures")!
+        let packageContent = try String(contentsOf: fixtureURL)
 
         let parser = PackageParser()
         let packageInfo = try await parser.parseContent(packageContent, packageDirectory: "/tmp/test")


### PR DESCRIPTION
Adds support for dependency constants like:

```swift
private let TCA = Target.Dependency.product(name: "ComposableArchitecture", package: "swift-composable-architecture")
```

- Resolves constant references in dependency arrays (e.g., `dependencies: [TCA]`)
- Maintains backward compatibility with existing dependency declaration methods

Closes #13 