### PR TITLE
Fix conditional product dependency parsing bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added support for `open` access modifier in dependency constants
   - Fixed parsing of dependency constants without explicit access modifiers (defaults to `internal`)
 
+- **Conditional Product Dependency Parsing**
+  - Fixed bug where products declared after conditional dependencies with platform-specific conditions were ignored during parsing
+  - Enhanced bracket counting algorithm to properly handle nested brackets within parentheses (e.g., `condition: .when(platforms: [.tvOS])`)
+  - Section extraction now correctly ignores square brackets inside parentheses to prevent premature parsing termination
+  - Resolves issue where dependencies like `RxSwift` were missed when following conditional products like `MyModuleTV` with platform conditions
+
 ## [v1.4.0]
 
 ### Changed

--- a/Tests/SwiftDependencyAuditTests/Fixtures/ConditionalBugPackage.swift
+++ b/Tests/SwiftDependencyAuditTests/Fixtures/ConditionalBugPackage.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.0
+// Test fixture demonstrating the bug where products after conditional dependencies are ignored
+import PackageDescription
+
+let package = Package(
+    name: "ConditionalBugPackage",
+    dependencies: [
+        .package(url: "https://github.com/example/MyModuleTV", from: "1.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift", from: "6.0.0"),
+        .package(url: "https://github.com/example/AnotherPackage", from: "1.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "TestTarget",
+            dependencies: [
+                .product(name: "MyModuleTV", package: "MyModuleTV", condition: .when(platforms: [.tvOS])),
+                .product(name: "RxSwift", package: "RxSwift"),
+                .product(name: "AnotherProduct", package: "AnotherPackage")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
Fix issue where products declared after conditional dependencies with platform-specific conditions were ignored during parsing (e.g., `condition: .when(platforms: [.tvOS])`).

Fixes #16.