### PR TITLE
Add Synchronization to isStandardLibraryModule

### DIFF
--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -420,6 +420,7 @@ public actor ImportScanner {
             "SwiftUI",
             "SwiftUICore",
             "Symbols",
+            "Synchronization",
             "SyncServices",
             "System",
             "SystemConfiguration",


### PR DESCRIPTION
Adds `Synchronization` to the `isStandardLibraryModule` check.