### PR TITLE
Add Observation to isStandardLibraryModule

### DIFF
--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -356,6 +356,7 @@ public actor ImportScanner {
             "NetworkExtension",
             "NotificationCenter",
             "ObjectiveC",
+            "Observation",
             "OpenAL",
             "OpenCL",
             "OpenDirectory",


### PR DESCRIPTION
Adds Observation to isStandardLibraryModule.

Sorry @tonyarnold! I didn't see this error earlier. :)