### PR TITLE
Handle trailing comments on imports

### DIFF
--- a/Sources/SwiftDependencyAuditLib/ImportScanner.swift
+++ b/Sources/SwiftDependencyAuditLib/ImportScanner.swift
@@ -35,6 +35,11 @@ public actor ImportScanner {
             }
         }
         ZeroOrMore(.whitespace)
+        // Handle trailing comments
+        ZeroOrMore {
+            "//"
+            ZeroOrMore(.anyNonNewline)
+        }
         Anchor.endOfLine
     }
 

--- a/Tests/SwiftDependencyAuditTests/ImportScannerTests.swift
+++ b/Tests/SwiftDependencyAuditTests/ImportScannerTests.swift
@@ -192,4 +192,19 @@ struct ImportScannerTests {
         let testableImport = imports.first { $0.moduleName == "TestableModule" }
         #expect(testableImport?.isTestable == true)
     }
+
+    @Test("Trailing comments on imports")
+    func testTrailingCommentsOnImports() async throws {
+        let scanner = ImportScanner()
+        let content = """
+            import RegularModule // A trailing comment
+            """
+
+        let imports = await scanner.scanContent(content)
+
+        // Foundation should be filtered out, leaving 6 custom modules
+        #expect(imports.count == 1)
+        let moduleNames = Set(imports.map { $0.moduleName })
+        #expect(moduleNames.contains("RegularModule"))
+    }
 }


### PR DESCRIPTION
I noticed that trailing comments on an import would cause the ImportScanner to ignore the import. This adds an optional trailing comment to the parser.