### PR TITLE
Add an .editorconfig to the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+tab_width = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
I'm not sure if you want this or not. All good either way. 

I noticed that my Xcode settings didn't match the coding style of the project, so thought this might be useful to at least match tab width etc.